### PR TITLE
Enabled request body for GET method (to help develop against elasticsearch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /restclient-cli/target/
 /restclient-jfx/target/
 /target/
+.idea
+*.iml

--- a/restclient-lib/src/main/java/org/wiztools/restclient/util/HttpUtil.java
+++ b/restclient-lib/src/main/java/org/wiztools/restclient/util/HttpUtil.java
@@ -164,7 +164,7 @@ public final class HttpUtil {
     
     private static final List<String> entityEnclosingMethods = 
             Collections.unmodifiableList(
-                    Arrays.asList(new String[]{"POST", "PUT", "PATCH", "DELETE"}));
+                    Arrays.asList(new String[]{"GET", "POST", "PUT", "PATCH", "DELETE"}));
     public static boolean isEntityEnclosingMethod(final String method) {
         return entityEnclosingMethods.contains(method);
     }

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTViewImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTViewImpl.java
@@ -104,7 +104,6 @@ public class RESTViewImpl extends JPanel implements RESTView {
         jtp.addTab("Cookie", jp_2col_req_cookies);
         
         // Body Tab
-        jp_req_body.disableBody(); // disable control by default
         jtp.addTab("Body", jp_req_body.getComponent());
         
         // Auth

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqmethod/ReqMethodPanelImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqmethod/ReqMethodPanelImpl.java
@@ -32,7 +32,8 @@ public class ReqMethodPanelImpl extends JPanel implements ReqMethodPanel {
     
     @Override
     public boolean doesSelectedMethodSupportEntityBody() {
-        return jrb_req_post.isSelected()
+        return jrb_req_get.isSelected()
+            || jrb_req_post.isSelected()
             || jrb_req_put.isSelected()
             || jrb_req_patch.isSelected()
             || jrb_req_delete.isSelected();


### PR DESCRIPTION
Hello, I've created this patch to enable the request body panel for GET requests as well. Although per specification, request body for GETs is semantically void and servers are supposed to ignore it, it's not out of standard to send such requests.

As a matter of fact, the popular search server elasticsearch uses such feature https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html