### PR TITLE
treat application/x-www-form-urlencoded response as text

### DIFF
--- a/restclient-lib/src/main/java/org/wiztools/restclient/util/HttpUtil.java
+++ b/restclient-lib/src/main/java/org/wiztools/restclient/util/HttpUtil.java
@@ -141,6 +141,7 @@ public final class HttpUtil {
         return ct.startsWith("text/")
                 || isXmlContentType(ct)
                 || isJsonContentType(ct)
+                || isFormUrlEncodedContentType(ct)
                 || TEXT_CT.contains(ct);
     }
     
@@ -173,6 +174,11 @@ public final class HttpUtil {
         final String ct = getContentTypeBeforeSemiColon(contentType);
         return ct.startsWith("text/html")
                 || ct.endsWith("+html");
+    }
+
+    public static boolean isFormUrlEncodedContentType(final String contentType) {
+        final String ct = getContentTypeBeforeSemiColon(contentType);
+        return ct.startsWith("application/x-www-form-urlencoded");
     }
 
     public static Charset getCharsetDefault(final ContentType type) {


### PR DESCRIPTION
Change to treat application/x-www-form-urlencoded responses as text. It is better than binary formatting.

Fixes #59 at least in some way. Being able to chage between binary and text is an extra.