### PR TITLE
Auto fill 'method、body、head ......' when select a url from url_combox

### DIFF
--- a/restclient-lib/build.gradle
+++ b/restclient-lib/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 dependencies {
   compile project(':restclient-server'),
-    'com.google.inject:guice:4.1.0',
+    'com.google.inject:guice:3.0',
     'com.mycila.guice.extensions:mycila-guice-jsr250:3.6.ga',
     'junit:junit:4.12',
     'org.codehaus.jackson:jackson-mapper-asl:1.9.13',

--- a/restclient-ui/build.gradle
+++ b/restclient-ui/build.gradle
@@ -24,6 +24,7 @@ macAppBundle {
   bundleCopyright = 'Copyright 2016 WizTools.org'
   bundleExtras.put("NSHighResolutionCapable", "true")
   javaProperties.put("file.encoding", "utf-8")
+  javaProperties.put("Dfile.encoding", "gbk")
   javaXProperties.add("mx1024M")
   // backgroundImage = "doc/macbackground.png"
 }
@@ -55,6 +56,8 @@ dependencies {
     'com.jidesoft:jide-oss:3.6.14',
     'org.swinglabs.swingx:swingx-autocomplete:1.6.5-1',
     'com.fifesoft:rsyntaxtextarea:2.5.8',
-    'org.simplericity.macify:macify:1.6'
+    'org.simplericity.macify:macify:1.6',
+    'dom4j:dom4j:1.6.1',
+    'org.xerial:sqlite-jdbc:3.8.11.2'
   testCompile 'junit:junit:4.+'
 }

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/FileOpenUtil.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/FileOpenUtil.java
@@ -23,7 +23,7 @@ public class FileOpenUtil {
         try {
             PersistenceRead p = new XmlPersistenceRead();
             Request request = p.getRequestFromFile(f);
-            view.setUIFromRequest(request);
+            view.setUIFromRequest(request, true);
         }
         catch(IOException | XMLException ex){
             e = ex;
@@ -55,7 +55,7 @@ public class FileOpenUtil {
             Request request = encp.getRequestBean();
             Response response = encp.getResponseBean();
             if(request != null && response != null){
-                view.setUIFromRequest(request);
+                view.setUIFromRequest(request,true);
                 view.setUIFromResponse(response);
             }
             else{

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTMain.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTMain.java
@@ -259,7 +259,7 @@ class RESTMain implements RESTUserInterface {
             @Override
             public void actionPerformed(ActionEvent e) {
                 view.clearUIResponse();
-                view.clearUIRequest();
+                view.clearUIRequest(true);
             }
         });
         jm_edit.add(jmi_reset_all);
@@ -297,13 +297,13 @@ class RESTMain implements RESTUserInterface {
                     try {
                         Request reqFromUi = view.getRequestFromUI();
                         if(!reqFromUi.equals(historyManager.current())) {
-                            view.setUIFromRequest(historyManager.current());
+                            view.setUIFromRequest(historyManager.current(), true);
                             return;
                         }
                     }
                     catch(IllegalStateException ex) {
                         if(historyManager.current() != null) {
-                            view.setUIFromRequest(historyManager.current());
+                            view.setUIFromRequest(historyManager.current(), true);
                             return;
                         }
                     }
@@ -313,7 +313,7 @@ class RESTMain implements RESTUserInterface {
                 if(!historyManager.isOldest()) {
                     Request request = historyManager.back();
                     if(request != null) {
-                        view.setUIFromRequest(request);
+                        view.setUIFromRequest(request, true);
                     }
                 }
                 else {
@@ -332,7 +332,7 @@ class RESTMain implements RESTUserInterface {
                 if(!historyManager.isMostRecent()) {
                     Request request = historyManager.forward();
                     if(request != null) {
-                        view.setUIFromRequest(request);
+                        view.setUIFromRequest(request, true);
                     }
                 }
                 else {

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTView.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTView.java
@@ -30,8 +30,10 @@ public interface RESTView extends View {
     Font getTextAreaFont();
 
     String getUrl();
-
+	
     HistoryManager getHistoryManager();
+	
+    Boolean isNeedEntity();
 
     void runClonedRequestTest(Request request, Response response);
 
@@ -42,6 +44,8 @@ public interface RESTView extends View {
     void setTextAreaScrollSpeed(final int scrollSpeed);
 
     void setUrl(String url);
+
+    void setMethod(String methodName);
 
     void showError(final String error);
     void showError(final Throwable ex);
@@ -58,4 +62,6 @@ public interface RESTView extends View {
     void setUIToLastRequestResponse();
     
     Container getContainer();
+
+    void setResBody(String postData, String contentType);
 }

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTView.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTView.java
@@ -6,6 +6,7 @@ import java.awt.Font;
 import org.wiztools.restclient.View;
 import org.wiztools.restclient.bean.Request;
 import org.wiztools.restclient.bean.Response;
+import org.wiztools.restclient.ui.history.HistoryManager;
 
 /**
  *
@@ -30,6 +31,8 @@ public interface RESTView extends View {
 
     String getUrl();
 
+    HistoryManager getHistoryManager();
+
     void runClonedRequestTest(Request request, Response response);
 
     void setStatusMessage(final String msg);
@@ -45,12 +48,12 @@ public interface RESTView extends View {
 
     void showMessage(final String title, final String message);
     
-    void setUIFromRequest(Request request);
+    void setUIFromRequest(Request request, Boolean isNeedSetUrl);
     void setUIFromResponse(Response response);
     
     void clearUIResponse();
     
-    void clearUIRequest();
+    void clearUIRequest(Boolean isNeedClearUrl);
     
     void setUIToLastRequestResponse();
     

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTViewImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTViewImpl.java
@@ -220,9 +220,14 @@ public class RESTViewImpl extends JPanel implements RESTView {
     @Override
     public void setUIToLastRequestResponse(){
         if(historyManager.lastRequest() != null && lastResponse != null){
-            setUIFromRequest(historyManager.lastRequest());
+            setUIFromRequest(historyManager.lastRequest(), true);
             setUIFromResponse(lastResponse);
         }
+    }
+
+    @Override
+    public HistoryManager getHistoryManager() {
+        return historyManager;
     }
     
     @Override
@@ -498,9 +503,11 @@ public class RESTViewImpl extends JPanel implements RESTView {
     }
     
     @Override
-    public void clearUIRequest() {
+    public void clearUIRequest(Boolean isNeedClearUrl) {
         // URL
-        jp_url_go.clear();
+        if (isNeedClearUrl) {
+            jp_url_go.clear();
+        }
         
         // Method
         jp_req_method.clear();
@@ -553,12 +560,14 @@ public class RESTViewImpl extends JPanel implements RESTView {
     }
     
     @Override
-    public void setUIFromRequest(final Request request){
+    public void setUIFromRequest(final Request request, Boolean isNeedSetUrl){
         // Clear first
-        clearUIRequest();
+        clearUIRequest(isNeedSetUrl);
 
         // URL
-        jp_url_go.setUrlString(request.getUrl().toString());
+        if (isNeedSetUrl) {
+            jp_url_go.setUrlString(request.getUrl().toString());
+        }
 
         // Method
         final HTTPMethod reqMethod = request.getMethod();

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/CommandDefined.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/CommandDefined.java
@@ -1,0 +1,54 @@
+package org.wiztools.restclient.ui.customrest;
+
+/**
+ * created by 10192065 on 2017/8/30
+ * User: 10192065(yzg)
+ * Date: 2017/8/30
+ */
+public class CommandDefined {
+    String method;
+    String port;
+    String commandName;
+    String command;
+    String params;
+    String tips;
+    String postData;
+    String bodyType;
+    String contentType;
+
+    public CommandDefined(String sMethod, String sPort, String sCommandName,
+                          String sCommand, String sParams, String sTips,
+                          String sPostData, String sContentType, String sBodyType) {
+        method = sMethod;
+        port = sPort;
+        commandName = sCommandName;
+        command = sCommand;
+        if (null == sParams) {
+            params = "";
+        } else {
+            params = sParams;
+        }
+        if (null == sTips) {
+            tips = "";
+        } else {
+            tips = sTips;
+        }
+        if (null == sPostData) {
+            postData = "";
+        } else {
+            postData = sPostData;
+        }
+        if (null == sContentType) {
+            contentType = "application/json;utf-8";
+        } else {
+            contentType = sContentType;
+        }
+
+        if (null == sBodyType) {
+            bodyType = "string";
+        } else {
+            bodyType = sBodyType;
+        }
+
+    }
+}

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/CustomDebugView.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/CustomDebugView.java
@@ -1,0 +1,34 @@
+package org.wiztools.restclient.ui.customrest;
+
+import com.google.inject.ImplementedBy;
+import org.wiztools.restclient.ui.ViewPanel;
+
+/**
+ * created by 10192065 on 2017/8/31
+ * User: 10192065(yzg)
+ * Date: 2017/8/31
+ */
+
+@ImplementedBy(CustomDebugViewImpl.class)
+public interface CustomDebugView extends ViewPanel {
+
+    String getTipsString();
+
+    String getPostData();
+
+    String getCommandCatag();
+
+    String getCommandSubName();
+
+    String getCommandFullName();
+
+    Boolean isPost();
+
+    String getLastCmd();
+
+    String getCmd();
+
+    void setHostIp();
+
+
+}

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/CustomDebugViewImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/CustomDebugViewImpl.java
@@ -1,0 +1,757 @@
+package org.wiztools.restclient.ui.customrest;
+
+/**
+ * created by 10192065 on 2017/8/31
+ * User: 10192065(yzg)
+ * Date: 2017/8/31
+ */
+
+import java.awt.*;
+import java.awt.event.*;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.swing.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
+import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
+import org.wiztools.restclient.IGlobalOptions;
+import org.wiztools.restclient.ui.RESTUserInterface;
+import org.wiztools.restclient.ui.RESTView;
+import org.wiztools.restclient.util.ConfigUtil;
+import org.wiztools.restclient.util.Util;
+
+
+public class CustomDebugViewImpl extends JPanel implements CustomDebugView {
+    private static final Logger LOG = Logger.getLogger(CustomDebugViewImpl.class.getName());
+    @Inject RESTView view;
+
+    @Inject private RESTUserInterface rest_ui;
+
+    // 上一次使用的filePath记录放到用户目录文件夹中的xmlPath.recode文件中
+    File recodeFile = ConfigUtil.getConfigFile("xmlPath.recode");
+
+    private List<String> xmlFilePaths = getXmlPath();
+
+    XmlParse xmlParse = new XmlParse(view, xmlFilePaths);
+
+    private Boolean isIpNeedSync = true;
+
+    private Map<String, CommandDefined> commandUnion = xmlParse.getAllCommand();
+    private Map<String, List<String>> commandNames = xmlParse.getAllCmdName();
+
+    private FormCommand formUtil = new FormCommand();
+
+    private String lastCommand = "tools init";
+
+    // 加载新的xml文件的按钮，点击之后会加载新的XML文件，并将记录写入文件记录起来
+    private final JButton loadXmlButn = new JButton("Load Xml");
+    // ip输入下拉框，并将新的ip写入数据库，以供可以选择历史数据
+
+    private JComboBox ipComboBox = new JComboBox();
+
+    // 类别选择框
+    private JComboBox catageComboBox = new JComboBox();
+
+    // 命令选择框
+    private JComboBox comComboBox = new JComboBox();
+
+    // 搜索框
+    private JTextField searchCtrl = new JTextField("");
+
+    // 参数输入框
+    private final RSyntaxTextArea paramCtrl = new RSyntaxTextArea();
+
+
+    private final SqlDataBase sqlObject = new SqlDataBase(view);
+
+    @PostConstruct
+    protected void init() {
+        initcatageComboBox();
+        initcmdComboBox();
+        initIpCombox();
+        initParamCtrl();
+        initSearchCtrl();
+        Sizer();
+        initListener();
+        lastCommand = getCommand();
+    }
+
+    // 页面布局
+    private void Sizer() {
+        setLayout(new BorderLayout());
+
+        JPanel admaPanelRow1 = new JPanel();
+        admaPanelRow1.setLayout(new FlowLayout(FlowLayout.LEFT));
+
+
+        JLabel jl_url = new JLabel("Host   : ");
+        jl_url.setLabelFor(ipComboBox);
+        jl_url.setDisplayedMnemonic('u');
+        ipComboBox.setToolTipText("Enter or choose a Ip");
+        loadXmlButn.setToolTipText("Load Cmd from Xml files!!!");
+
+        JTextField blank = new JTextField();
+        blank.setPreferredSize(new Dimension(320,0));
+
+        admaPanelRow1.add(jl_url);
+        admaPanelRow1.add(ipComboBox);
+        admaPanelRow1.add(blank);
+        admaPanelRow1.add(loadXmlButn);
+
+        add(admaPanelRow1, BorderLayout.NORTH);
+
+        JPanel admaPanelRow2 = new JPanel();
+        admaPanelRow2.setLayout(new FlowLayout(FlowLayout.LEFT));
+
+        JLabel catagLabel = new JLabel("Group: ");
+        catagLabel.setLabelFor(catageComboBox);
+        catagLabel.setDisplayedMnemonic('u');
+
+        catageComboBox.setToolTipText("Choose the Group......");
+
+
+
+        JLabel cmdLabel = new JLabel("CMD : ");
+        cmdLabel.setLabelFor(comComboBox);
+        cmdLabel.setDisplayedMnemonic('u');
+        comComboBox.setToolTipText("Choose Command......");
+        Dimension cd = catageComboBox.getPreferredSize();
+        cd.width = cd.width + 100;
+        catageComboBox.setPreferredSize(cd);
+
+        Dimension scd = comComboBox.getPreferredSize();
+        scd.width = scd.width + 200;
+        comComboBox.setPreferredSize(scd);
+
+        admaPanelRow2.add(catagLabel);
+        admaPanelRow2.add(catageComboBox);
+        admaPanelRow2.add(cmdLabel);
+        admaPanelRow2.add(comComboBox);
+
+        JLabel searchLabel = new JLabel("Search: ");
+        searchLabel.setLabelFor(searchCtrl);
+        searchLabel.setDisplayedMnemonic('u');
+        searchCtrl.setToolTipText("Search Command...");
+
+        Dimension sscd = searchCtrl.getPreferredSize();
+        sscd.width = sscd.width + 100;
+        searchCtrl.setPreferredSize(sscd);
+
+        admaPanelRow2.add(searchLabel);
+        admaPanelRow2.add(searchCtrl);
+
+        add(admaPanelRow2, BorderLayout.CENTER);
+
+        JScrollPane jsp = new JScrollPane(paramCtrl);
+        Dimension jcd = jsp.getPreferredSize();
+        jcd.height = jcd.height + 150;
+        jsp.setPreferredSize(jcd);
+        add(jsp, BorderLayout.SOUTH);
+
+    }
+
+
+    @Override
+    public String getTipsString() {
+        String catalog = null;
+        String subCmd = null;
+        Object cataItem = catageComboBox.getSelectedItem();
+        Object subCmdItem = comComboBox.getSelectedItem();
+
+        if (null != cataItem) {
+            catalog = cataItem.toString();
+        }
+        if (null != subCmdItem) {
+            subCmd = subCmdItem.toString();
+        }
+
+        String cmd = null;
+        if (catalog != null && subCmd != null) {
+            if (catalog == "无类别" || catalog == "all") {
+                cmd = subCmd;
+            } else {
+                cmd = catalog + "_" + subCmd;
+            }
+        }
+
+        if (null != cmd) {
+            return commandUnion.get(cmd).tips;
+        }
+        return "";
+    }
+
+    @Override
+    public String getPostData() {
+        String catalog = "";
+        String subCmd = "";
+        Object catalogItem = catageComboBox.getSelectedItem();
+        Object subCmdItem = comComboBox.getSelectedItem();
+
+        if(null != catalogItem) {
+            catalog = catalogItem.toString();
+        }
+        if (null != subCmdItem) {
+            subCmd = subCmdItem.toString();
+        }
+        String cmd = null;
+        if (catalog != "" && subCmd != "") {
+            if (catalog == "无类别" || catalog == "all") {
+                cmd = subCmd;
+            } else {
+                cmd = catalog + "_" + subCmd;
+            }
+        }
+
+        if (null != cmd) {
+            return commandUnion.get(cmd).postData;
+        }
+        return "";
+    }
+
+    private String  getContentType() {
+        String catalog = "";
+        String subCmd = "";
+        Object catalogItem = catageComboBox.getSelectedItem();
+        Object subCmdItem = comComboBox.getSelectedItem();
+
+        if(null != catalogItem) {
+            catalog = catalogItem.toString();
+        }
+        if (null != subCmdItem) {
+            subCmd = subCmdItem.toString();
+        }
+        String cmd = null;
+        if (catalog != "" && subCmd != "") {
+            if (catalog == "无类别" || catalog == "all") {
+                cmd = subCmd;
+            } else {
+                cmd = catalog + "_" + subCmd;
+            }
+        }
+
+        if (null != cmd) {
+            return commandUnion.get(cmd).contentType;
+        }
+        return "";
+    }
+
+    @Override
+    public String getCommandCatag() {
+        return catageComboBox.getSelectedItem().toString();
+    }
+
+    @Override
+    public String getCommandSubName() {
+        return comComboBox.getSelectedItem().toString();
+    }
+
+    @Override
+    public String getCommandFullName() {
+        String catalog = catageComboBox.getSelectedItem().toString();
+        String subCmd = comComboBox.getSelectedItem().toString();
+        String cmd = null;
+        if (catalog != "" && subCmd != "") {
+            if (catalog == "无类别" || catalog == "all") {
+                cmd = subCmd;
+            } else {
+                cmd = catalog + "_" + subCmd;
+            }
+        }
+
+        if (null != cmd) {
+            return cmd;
+        }
+        return "";
+    }
+
+    @Override
+    public Boolean isPost() {
+        String catalog = catageComboBox.getSelectedItem().toString();
+        String subCmd = comComboBox.getSelectedItem().toString();
+        String cmd = null;
+        if (catalog != "" && subCmd != "") {
+            if (catalog == "无类别" || catalog == "all") {
+                cmd = subCmd;
+            } else {
+                cmd = catalog + "_" + subCmd;
+            }
+        }
+
+        if (null != cmd) {
+            return commandUnion.get(cmd).method.toLowerCase().trim() == "post";
+        }
+        return false;
+    }
+
+    @Override
+    public void clear() {
+        catageComboBox.removeAllItems();
+        comComboBox.removeAllItems();
+        ipComboBox.removeAllItems();
+        searchCtrl.setText("");
+        paramCtrl.setText("");
+    }
+
+    @Override
+    public Component getComponent() {
+        return this;
+    }
+
+
+    private String getParams() {
+        String catalog;
+        String subCmd;
+        Object catalogItem = catageComboBox.getSelectedItem();
+        if(null != catalogItem){
+            catalog = catalogItem.toString();
+        }
+        else {
+            catalog = "";
+        }
+        Object subCmdItem = comComboBox.getSelectedItem();
+        if (null != subCmdItem) {
+            subCmd = subCmdItem.toString();
+        } else {
+            subCmd = "";
+        }
+        String cmd = null;
+        if (catalog != "" && subCmd != "") {
+            if (catalog == "无类别" || catalog == "all") {
+                cmd = subCmd;
+            } else {
+                cmd = catalog + "_" + subCmd;
+            }
+        }
+
+        if (null != cmd) {
+            return commandUnion.get(cmd).params;
+        }
+        return "";
+    }
+
+
+    private void initParamCtrl() {
+        // 自动换行
+        paramCtrl.setLineWrap(true);
+        paramCtrl.setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_NONE);
+        paramCtrl.setText(getParams());
+
+    }
+
+    private void initSearchCtrl() {
+        searchCtrl.setName("SEARCH");
+    }
+
+    private void initListener() {
+        // 重新加载xml文件按钮事件
+        loadXmlButn.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                JFileChooser jFile = new JFileChooser(IGlobalOptions.CONF_DIR);
+                xmlFileFilter fileFilter=new xmlFileFilter();
+                jFile.setFileSelectionMode(JFileChooser.FILES_ONLY);
+                jFile.setMultiSelectionEnabled(true);
+                jFile.setFileFilter(fileFilter);
+                jFile.showDialog(new JLabel(), "Choose.......");
+                File[] files = jFile.getSelectedFiles();
+                List<String> lFiles = new ArrayList();
+                for (File file : files) {
+                    lFiles.add(file.getAbsolutePath());
+                }
+                if (!lFiles.isEmpty()) {
+                    writeXmlPath(lFiles);
+                }
+            }
+        });
+
+        // ip选择框输入更新事件
+        final JTextField editorComponent = (JTextField) ipComboBox.getEditor().getEditorComponent();
+        editorComponent.addKeyListener(new KeyAdapter() {
+
+            public void keyPressed(KeyEvent e) {
+                String ip = editorComponent.getText();
+                if (ipCheck(ip)) {
+                    editorComponent.setForeground(Color.GREEN);
+                } else {
+                    editorComponent.setForeground(Color.RED);
+                }
+                lastCommand = getCommand();
+            }
+        });
+
+        // IP选择框选择IP时要同步更新command
+        ipComboBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                // 值改变的时候更新command
+                // lastCommand = getCommand();
+                if (isIpNeedSync) {
+                    LOG.log(Level.INFO, "ip selected and set!");
+                    setUiCommand();
+                }
+                isIpNeedSync = true;
+            }
+        });
+
+
+        // 参数填写框更新事件
+        paramCtrl.addKeyListener(new KeyAdapter() {
+            public void keyReleased(KeyEvent e) {
+                setUiCommand();
+                LOG.log(Level.INFO, "params update and set!");
+
+            }
+        });
+
+        // 类型选择框事件响应函数，需要同步更新命令选择框和参数区域
+        catageComboBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                // 同步更新subcmd 和params
+                String catalog = "";
+                Object cataItem = catageComboBox.getSelectedItem();
+                if (null != cataItem) {
+                    catalog = cataItem.toString();
+                }
+                if (commandNames.keySet().contains(catalog)) {
+                    List<String> subCmds = commandNames.get(catalog);
+                    comComboBox.removeAllItems();
+                    for (String item : subCmds) {
+                        comComboBox.addItem(item);
+                    }
+                    if (!subCmds.isEmpty()) {
+                        // 更新下拉框，并且更新参数区域
+                        comComboBox.setSelectedItem(subCmds.toArray()[0]);
+                        paramCtrl.setText(getParams());
+                        setUiCommand();
+                        LOG.log(Level.INFO, "catalog selected and set!");
+                    }
+                } else {
+                    LOG.log(Level.WARNING,"None of " + catalog + "has configure in xml file!");
+                }
+            }
+        });
+
+        // 子命令选择框事件
+        comComboBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                paramCtrl.setText(getParams());
+                LOG.log(Level.INFO, "subType selected and set!");
+                setUiCommand();
+            }
+        });
+
+        // 搜索框响应文本改变事件，需要设置类别框为all，并更新命令选择下拉框
+        searchCtrl.addKeyListener(new KeyAdapter() {
+            public void keyTyped(KeyEvent e) {
+                // TODO 同步更新catalog和命令框 当为“”时要恢复命令框
+                if (searchCtrl.getText() == "") {
+                    initcatageComboBox();
+                    initcmdComboBox();
+                    initParamCtrl();
+                } else {
+                    catageComboBox.setSelectedItem("all");
+                    comComboBox.removeAllItems();
+                    Set<String> cmdName = commandUnion.keySet();
+                    String seachKey = searchCtrl.getText();
+                    String lastKey = null;
+                    for (String cmd : cmdName) {
+                        if (cmd.contains(seachKey)) {
+                            comComboBox.addItem(cmd);
+                            lastKey = cmd;
+                        }
+                    }
+                    if (lastKey != null) {
+                        comComboBox.setSelectedItem(lastKey);
+                        paramCtrl.setText(getParams());
+                        lastCommand = getCommand();
+                    }
+
+                }
+            }
+        });
+
+    }
+
+    @Override
+    public void setHostIp() {
+        // 处理回车，将IP写入到数据库中去
+        // 校验IP是否合法,合法将其写入数据库，并更新IP选择框
+        String ip = "";
+        Object ipItem = ipComboBox.getSelectedItem();
+        if(null != ipItem) {
+            ip = ipItem.toString();
+        }
+
+        if (ipCheck(ip)) {
+            sqlObject.insertIpRecode(ip);
+            List<String> ipList = sqlObject.getIpRecode();
+            isIpNeedSync = false;
+            ipComboBox.removeAllItems();
+            for (String host : ipList) {
+                isIpNeedSync = false;
+                ipComboBox.addItem(host);
+            }
+            isIpNeedSync = false;
+            ipComboBox.setSelectedItem(ip);
+        }
+    }
+
+    private static boolean ipCheck(String text) {
+        if (text != null && !text.isEmpty()) {
+            // 定义正则表达式
+            String regex = "^(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|[1-9])\\." +
+                    "(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)\\." +
+                    "(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)\\." +
+                    "(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)$";
+            // 判断ip地址是否与正则表达式匹配
+            if (text.matches(regex)) {
+                // 返回判断信息
+                return true;
+            } else {
+                // 返回判断信息
+                return false;
+            }
+        }
+        return false;
+    }
+
+
+    private void initcatageComboBox() {
+        // 初始化类别下拉框
+        catageComboBox.removeAllItems();
+        catageComboBox.setToolTipText("选择分类....");
+        catageComboBox.setEditable(false);
+        Set<String> allCatag = commandNames.keySet();
+        for (String key : allCatag) {
+            catageComboBox.addItem(key);
+        }
+        catageComboBox.setSelectedItem("all");
+    }
+
+    private void initcmdComboBox() {
+        // 初始化类别下拉框
+        comComboBox.removeAllItems();
+        comComboBox.setToolTipText("选择命令....");
+        comComboBox.setEditable(false);
+        Object catalogItem = catageComboBox.getSelectedItem();
+        if (null != catalogItem) {
+            String catalog = catalogItem.toString();
+            if (commandNames.keySet().contains(catalog)) {
+                List<String> commands = commandNames.get(catalog);
+                for (String cmd : commands) {
+                    comComboBox.addItem(cmd);
+                }
+                comComboBox.setSelectedItem(commands.toArray()[0]);
+            }
+        }
+    }
+
+    private void initIpCombox() {
+        // 初始化ip下拉框
+        ipComboBox.setToolTipText("HOST");
+        ipComboBox.setEditable(true);
+//        JLabel jl_url = new JLabel("HOST: ");
+//        jl_url.setLabelFor(ipComboBox);
+//        jl_url.setDisplayedMnemonic('u');
+        List<String> ipList = sqlObject.getIpRecode();
+        for (String ip : ipList) {
+            ipComboBox.addItem(ip);
+        }
+        if (!ipList.isEmpty()) {
+            ipComboBox.setSelectedItem(ipList.toArray()[0]);
+        }
+    }
+
+    @Override
+    public String getLastCmd() {
+        return lastCommand;
+    }
+
+    @Override
+    public String getCmd() {
+        String catalog = "";
+        String subCmd = "";
+        Object cataItem = catageComboBox.getSelectedItem();
+        Object comboItem = comComboBox.getSelectedItem();
+
+        if (null != cataItem) {
+            catalog = cataItem.toString();
+        }
+        if (null != comboItem) {
+            subCmd = comboItem.toString();
+        }
+        String cmd = null;
+        if (catalog != "" && subCmd != "") {
+            if (catalog == "无类别" || catalog == "all") {
+                cmd = subCmd;
+            } else {
+                cmd = catalog + "_" + subCmd;
+            }
+        }
+        return cmd;
+    }
+
+    private void setUiCommand() {
+        lastCommand = getCommand();
+        comComboBox.setToolTipText(getTipsString());
+        view.setUrl(lastCommand);
+        view.setMethod(getMethod());
+        if (view.isNeedEntity()) {
+            view.setResBody(getPostData(), getContentType());
+        }
+    }
+
+
+    private String getMethod() {
+        String catalog = "";
+        String subCmd = "";
+        Object cataItem = catageComboBox.getSelectedItem();
+        Object comboItem = comComboBox.getSelectedItem();
+
+        if (null != cataItem) {
+            catalog = cataItem.toString();
+        }
+        if (null != comboItem) {
+            subCmd = comboItem.toString();
+        }
+
+        String cmd = null;
+        if (catalog != "" && subCmd != "") {
+            if (catalog == "无类别" || catalog == "all") {
+                cmd = subCmd;
+            } else {
+                cmd = catalog + "_" + subCmd;
+            }
+        }
+        if (null != cmd) {
+            CommandDefined cmdInfo = commandUnion.get(cmd);
+            return cmdInfo.method;
+        }
+        return "NONE";
+    }
+
+    private String getCommand() {
+        String ip = "";
+        String catalog = "";
+        String subCmd = "";
+        Object ipItem = ipComboBox.getSelectedItem();
+        Object cataItem = catageComboBox.getSelectedItem();
+        Object comboItem = comComboBox.getSelectedItem();
+
+        if (null != ipItem) {
+            ip = ipItem.toString();
+        }
+        if (null != cataItem) {
+            catalog = cataItem.toString();
+        }
+        if (null != comboItem) {
+            subCmd = comboItem.toString();
+        }
+
+        String params = paramCtrl.getText();
+        String cmd = null;
+        if (catalog != "" && subCmd != "") {
+            if (catalog == "无类别" || catalog == "all") {
+                cmd = subCmd;
+            } else {
+                cmd = catalog + "_" + subCmd;
+            }
+        }
+        if (null != cmd) {
+            CommandDefined cmdInfo = commandUnion.get(cmd);
+            return formUtil.FormCmd(ip, cmdInfo.port, cmdInfo.command, params);
+        }
+
+        return "debug tools";
+    }
+
+
+    /**
+     * 获取所有的命令
+     *
+     * @return
+     */
+    private Map<String, CommandDefined> getAllCommand() {
+        return xmlParse.getAllCommand();
+    }
+
+
+    private List<String> getXmlPath() {
+        Exception e = null;
+        List<String> lines = new ArrayList<>();
+        try {
+            if (!recodeFile.exists()) {
+                recodeFile.createNewFile();
+            } else if (recodeFile.isDirectory()) {
+                e = new Exception("xmlPath.recode is a directory!!!");
+            } else {
+                FileReader reader = new FileReader(recodeFile.getAbsolutePath());
+                BufferedReader br = new BufferedReader(reader);
+                String str;
+                while ((str = br.readLine()) != null) {
+                    if (!str.trim().isEmpty()) {
+                        lines.add(str);
+                    }
+                }
+                br.close();
+                reader.close();
+            }
+        } catch (Exception exp) {
+            e = exp;
+        }
+
+        if (null != e) {
+            view.showError(Util.getStackTrace(e));
+        }
+
+        return lines;
+    }
+
+    private void writeXmlPath(List<String> files) {
+        Exception e = null;
+        try {
+            if (!recodeFile.exists()) {
+                recodeFile.createNewFile();
+            } else if (recodeFile.isDirectory()) {
+                e = new Exception("xmlPath.recode is a directory!!!");
+            } else {
+                FileWriter writer = new FileWriter(recodeFile.getAbsolutePath());
+                BufferedWriter bw = new BufferedWriter(writer);
+                StringBuffer sb = new StringBuffer("");
+                for (String file : files) {
+                    sb.append(file + "\n");
+                }
+                bw.write(sb.toString().trim());
+                bw.flush();
+                bw.close();
+                writer.close();
+            }
+        } catch (Exception exp) {
+            e = exp;
+        }
+
+        if (null != e) {
+            view.showError(Util.getStackTrace(e));
+        }
+        // 数据写入之后，再次解析XML文件获取所有命令, 并更新选项框
+        xmlParse = new XmlParse(view, files);
+        commandUnion = xmlParse.getAllCommand();
+        commandNames = xmlParse.getAllCmdName();
+        initcatageComboBox();
+        initcmdComboBox();
+        initParamCtrl();
+        initSearchCtrl();
+        lastCommand = getCommand();
+
+    }
+
+}

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/FormCommand.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/FormCommand.java
@@ -1,0 +1,47 @@
+package org.wiztools.restclient.ui.customrest;
+
+/**
+ * created by 10192065 on 2017/8/30
+ * User: 10192065(yzg)
+ * Date: 2017/8/30
+ * 根据xml配置以及设置的IP等参数构造出一条完整的命令
+ */
+public final class FormCommand {
+
+    /**
+     * 形成完整的URL
+     *
+     * @param commandUnion xml建模好的对象
+     * @return 组装好的URL
+     */
+    String FormCmd(String ip, CommandDefined commandUnion) {
+        String command = commandUnion.command;
+        String[] params = commandUnion.params.split("\\$##\\$");
+        for (String param : params) {
+            command = command.replaceFirst("\\$##\\$", param);
+        }
+        // 可能提供的参数不全，将没替换的占位符全部替换掉
+        command = command.replaceAll("\\$##\\$", "");
+        if (command.startsWith("/")) {
+            return ("http://" + ip + ":" + commandUnion.port + command);
+        } else {
+            return ("http://" + ip + ":" + commandUnion.port + "/" + command);
+        }
+
+    }
+
+    String FormCmd(String ip, String port, String command, String sparams) {
+        String[] params = sparams.split("\\$##\\$");
+        for (String param : params) {
+            command = command.replaceFirst("\\$##\\$", param);
+        }
+        // 可能提供的参数不全，将没替换的占位符全部替换掉
+        command = command.replaceAll("\\$##\\$", "");
+        if (command.startsWith("/")) {
+            return ("http://" + ip + ":" + port + command);
+        } else {
+            return ("http://" + ip + ":" + port + "/" + command);
+        }
+
+    }
+}

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/SqlDataBase.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/SqlDataBase.java
@@ -1,0 +1,124 @@
+package org.wiztools.restclient.ui.customrest;
+
+import org.wiztools.restclient.ui.RESTView;
+import org.wiztools.restclient.util.ConfigUtil;
+import org.wiztools.restclient.util.Util;
+
+import java.io.File;
+import java.sql.*;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 数据库操作接口，写入
+ * created by 10192065 on 2017/8/31
+ * User: 10192065(yzg)
+ * Date: 2017/8/31
+ */
+public class SqlDataBase {
+    private static final Logger LOG = Logger.getLogger(SqlDataBase.class.getName());
+    private static final String TABLENAME = "recode_table";
+
+    private File recodeFile = ConfigUtil.getConfigFile("admadebug.db");
+    private String dbFile = recodeFile.getAbsolutePath();
+    private Connection conn = null;
+    Statement stmt = null;
+    RESTView view = null;
+
+    SqlDataBase(final RESTView view) {
+        initDatabase(view);
+    }
+
+    private void initDatabase(final RESTView view) {
+        try {
+            Class.forName("org.sqlite.JDBC");
+            conn = DriverManager.getConnection("jdbc:sqlite:"+ dbFile);
+            stmt = conn.createStatement();
+        } catch ( Exception e ) {
+            LOG.log(Level.WARNING, e.getClass().getName() + ": " + e.getMessage(), e);
+            view.showError(Util.getStackTrace(e));
+        }
+        LOG.log(Level.INFO,"Opened database successfully");
+        createTable(view);
+    }
+
+    private void createTable(final RESTView view) {
+        try {
+            String selectSql = "select * from " + TABLENAME + " limit 1;";
+            query(selectSql);
+        } catch ( Exception e ) {
+            String createSql = "create table if not exists [" + TABLENAME +
+                    "]([id] TEXT, [value] TEXT, [date] datetime default (getdate()), [info] TEXT, [comment] TEXT);";
+            execute(createSql);
+            LOG.log(Level.WARNING, e.getClass().getName() + ": " + e.getMessage(), e);
+//            view.showError(Util.getStackTrace(e));
+        }
+        LOG.log(Level.INFO,"create or find table successfully");
+    }
+
+
+    private void execute(String sql) {
+
+        try {
+            stmt.executeUpdate(sql);
+        } catch(Exception e) {
+            view.showError(Util.getStackTrace(e));
+        }
+    }
+
+    private ResultSet query(String sql) {
+        ResultSet result = null;
+        try {
+            result = stmt.executeQuery(sql);
+        } catch(Exception e) {
+            view.showError(Util.getStackTrace(e));
+        }
+        return result;
+    }
+
+    private String getDateString() {
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        return df.format(new java.util.Date());
+    }
+
+    public void insertIpRecode(String ipAddress) {
+        String time = getDateString();
+        // 首先要判断该IP是否存在，存在则更新时间，否则插入
+        String sqlStr = "SELECT value FROM " + TABLENAME + " where id='IP' and value='" + ipAddress + "';";
+        ResultSet rs = query(sqlStr);
+        try{
+            if (rs.next()) {
+                sqlStr = "UPDATE " + TABLENAME + " set date='" +time +"' where id='IP' and value='" +
+                        ipAddress + "';";
+            }
+            else {
+                sqlStr = "INSERT INTO " + TABLENAME + " (id, value, date, info, comment) " +
+                        "VALUES ('IP', '" + ipAddress + "', '" + time +"', '', '');";
+            }
+            execute(sqlStr);
+        } catch(Exception e) {
+            view.showError(Util.getStackTrace(e));
+        }
+    }
+
+    public List<String> getIpRecode() {
+        List<String> ipList = new ArrayList();
+        String sqlStr = "SELECT value FROM " + TABLENAME + " where id='IP' ORDER BY date DESC LIMIT 10;";
+        ResultSet rs = query(sqlStr);
+        try {
+            while(rs.next()){
+                ipList.add(rs.getString("value"));
+            }
+        } catch (Exception exp) {
+            view.showError(Util.getStackTrace(exp));
+        }
+        return ipList;
+    }
+
+
+
+
+}

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/XmlParse.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/XmlParse.java
@@ -1,0 +1,141 @@
+package org.wiztools.restclient.ui.customrest;
+
+import java.io.File;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.dom4j.Document;
+import org.dom4j.Element;
+import org.dom4j.io.SAXReader;
+import org.wiztools.restclient.ui.RESTView;
+import org.wiztools.restclient.util.Util;
+
+/**
+ * created by 10192065 on 2017/8/30
+ * User: 10192065(yzg)
+ * Date: 2017/8/30
+ */
+public class XmlParse {
+    private static final Logger LOG = Logger.getLogger(XmlParse.class.getName());
+
+    private Map<String, CommandDefined> commandUnion = new HashMap();
+
+    private Map<String, List<String>> commandNames = new HashMap();
+
+    public Map<String, CommandDefined> getAllCommand() {
+        return commandUnion;
+    }
+
+    public Map<String, List<String>> getAllCmdName() {
+        return commandNames;
+    }
+
+    private void parseComandNames() {
+        Set<String> keys = commandUnion.keySet();
+        commandNames.clear();
+        for (String key : keys) {
+            String catag = null;
+
+            // 无论是什么，都添加到all组别里面
+            if (commandNames.keySet().contains("all")) {
+                commandNames.get("all").add(key);
+            } else {
+                List<String> subCmd = new ArrayList();
+                subCmd.add(key);
+                commandNames.put("all", subCmd);
+            }
+
+            // 再根据具体情况进行细分
+            if (-1 != key.indexOf("_")) {
+                catag = key.split("_")[0];
+
+                // 如果已经包含这个类别，将命令添加到后面的list即可
+                if (commandNames.keySet().contains(catag)) {
+                    commandNames.get(catag).add(key.split("_")[1]);
+                } else {
+                    List<String> subCmd = new ArrayList();
+                    subCmd.add(key.split("_")[1]);
+                    commandNames.put(catag, subCmd);
+                }
+            } else {
+                // 如果不存在‘_’符号，默认没有进行类别分组，默认放到“无类别”组
+                if (commandNames.keySet().contains("无类别")) {
+                    commandNames.get("无类别").add(key);
+                } else {
+                    List<String> subCmd = new ArrayList();
+                    subCmd.add(key);
+                    commandNames.put("无类别", subCmd);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * 传入xml的文件路径
+     *
+     * @param view     视图
+     * @param filePath list形式的xml文件路径
+     */
+    XmlParse(final RESTView view, List<String> filePath) {
+        for (String oneFile : filePath) {
+            initXml(view, oneFile);
+        }
+        parseComandNames();
+    }
+
+
+    private void initXml(final RESTView view, String filePath) {
+        Exception e = null;
+        File file = new File(filePath);
+        SAXReader reader = new SAXReader();
+        try {
+            if (file.exists()) {
+                Document document = reader.read(file);
+                Element root = document.getRootElement();
+                String rootName = root.getName();
+                // 当且仅当标签为customcomand时才进行解析到内存
+                if (rootName == "customcomand") {
+                    List<Element> eleList = root.elements();
+                    // 解析所有的元素
+                    for (Element ele : eleList) {
+                        String port = "8889";
+                        String method = "get";
+                        String params = null;
+                        if (null != ele.attributeValue("method")) {
+                            method = ele.attributeValue("method");
+                        }
+                        if (null != ele.attributeValue("serviceport")) {
+                            port = ele.attributeValue("serviceport");
+                        }
+                        String commandName = ele.elementText("commandname");
+                        String command = ele.elementText("command");
+                        if(null != ele.elementText("params")) {
+                            params = ele.elementText("params");
+                        }
+                        String tips = ele.elementText("tips");
+                        String postData = ele.elementText("postdata");
+                        String contentType = ele.elementText("contenttype");
+                        String contentBody = ele.elementText("bodyType");
+                        CommandDefined commandInstance = new CommandDefined(method, port, commandName, command,
+                                params, tips, postData, contentType, contentBody);
+                        commandUnion.put(commandName, commandInstance);
+                    }
+                } else {
+                    e = new Exception("only support for customcomand!!!");
+                }
+            } else {
+                e = new Exception("file " + filePath + "is not exist!!!");
+            }
+        } catch (Exception execption) {
+            e = execption;
+
+        }
+
+        if (null != e) {
+            LOG.log(Level.WARNING, "error: "+ e);
+            view.showError(Util.getStackTrace(e));
+        }
+    }
+}

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/xmlFileFilter.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/customrest/xmlFileFilter.java
@@ -1,0 +1,17 @@
+package org.wiztools.restclient.ui.customrest;
+
+/**
+ * created by 10192065 on 2017/9/8
+ * User: 10192065(yzg)
+ * Date: 2017/9/8
+ */
+public class xmlFileFilter extends javax.swing.filechooser.FileFilter {
+    public boolean accept(java.io.File f) {
+        if (f.isDirectory()) return true;
+        return f.getName().endsWith(".xml");
+    }
+
+    public String getDescription() {
+        return ".xml";
+    }
+}

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/history/HistoryManager.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/history/HistoryManager.java
@@ -34,6 +34,10 @@ public interface HistoryManager {
     boolean isEmpty();
 
     void clear();
+
+    void setCursor(int sCurtor);
+
+    int cursor();
     
     void save(File file) throws IOException;
     void load(File file) throws IOException;

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/history/HistoryManagerImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/history/HistoryManagerImpl.java
@@ -95,6 +95,11 @@ public class HistoryManagerImpl implements HistoryManager {
             options.setProperty(HISTORY_SIZE_CONFIG_KEY, String.valueOf(maxSize));
         }
     }
+
+    @Override
+    public void setCursor(int sCurtor) {
+        cursor = sCurtor;
+    }
     
     @Override
     public int getHistorySize() {
@@ -220,7 +225,8 @@ public class HistoryManagerImpl implements HistoryManager {
     public int size() {
         return data.size();
     }
-    
+
+    @Override
     public int cursor() {
         return cursor;
     }

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqbody/BodyContentTypeDialog.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqbody/BodyContentTypeDialog.java
@@ -32,7 +32,7 @@ import org.wiztools.restclient.ui.RESTUserInterface;
 public class BodyContentTypeDialog extends EscapableDialog {
     
     private static final String[] contentTypeArr;
-    public static final String DEFAULT_CONTENT_TYPE = "text/plain";
+    public static final String DEFAULT_CONTENT_TYPE = "application/json";
     
     private static final String[] charSetArr;
     public static final String DEFAULT_CHARSET = "UTF-8";

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
@@ -99,6 +99,8 @@ public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
                         if (e.getStateChange() == ItemEvent.DESELECTED) {
                             rest_ui.getView().setUIFromRequest(matchRequest, false);
                         }
+                    } else {
+                        rest_ui.getView().clearUIRequest(false);
                     }
                 }
 

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
@@ -14,9 +14,11 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.swing.*;
 import org.wiztools.commons.StringUtil;
+import org.wiztools.restclient.bean.Request;
 import org.wiztools.restclient.ui.RESTUserInterface;
 import org.wiztools.restclient.ui.RESTView;
 import org.wiztools.restclient.ui.UIUtil;
+import org.wiztools.restclient.ui.history.HistoryManager;
 
 /**
  *
@@ -39,7 +41,33 @@ public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
     private final JButton jb_request = new JButton(icon_go);
     
     private final List<ActionListener> listeners = new ArrayList<>();
-    
+
+    private Request findMatchUrl(HistoryManager historyManger, String matchingUrl){
+        int currentCursor = historyManger.cursor();
+        Request backRequest;
+        Request forwardRequest;
+        Request currentRequest = historyManger.current();
+        if (null != currentRequest && currentRequest.getUrl().toString().equals(matchingUrl)) {
+            return currentRequest;
+        }
+        backRequest = historyManger.back();
+        while (null != backRequest) {
+            if (backRequest.getUrl().toString().equals(matchingUrl)) {
+                return backRequest;
+            }
+            backRequest = historyManger.back();
+        }
+        historyManger.setCursor(currentCursor);
+        forwardRequest = historyManger.forward();
+        while ( null != forwardRequest) {
+            if (forwardRequest.getUrl().toString().equals(matchingUrl)) {
+                return forwardRequest;
+            }
+            forwardRequest = historyManger.forward();
+        }
+        return null;
+    }
+
     @PostConstruct
     protected void init() {
         { // Keystroke for focusing on the address bar:
@@ -55,6 +83,27 @@ public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
                 }
             });
         }
+
+        // when url is selected, search the history and set method,body etc.
+        jcb_url.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                String url = "";
+                HistoryManager historyManager = rest_ui.getView().getHistoryManager();
+                Object urlObject = jcb_url.getSelectedItem();
+                if (null != urlObject) {
+                    url = urlObject.toString();
+                    Request matchRequest = findMatchUrl(historyManager, url);
+                    if (null != matchRequest) {
+                        // set method,body etc.
+                        if (e.getStateChange() == ItemEvent.DESELECTED) {
+                            rest_ui.getView().setUIFromRequest(matchRequest, false);
+                        }
+                    }
+                }
+
+            }
+        });
         
         // Layout follows:
         

--- a/tempData.xml
+++ b/tempData.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cunstomcomand>
+<!-- bodytype ©иртн╙ string, file, bytearray, urlstream, mutilpart -->
+	
+    <filed method="get" serviceport="8888">
+        <commandname>group_subcmd</commandname>
+        <command>test1/test2?param1=$##$&amp;param2=$##$</command>
+        <tips>some tips</tips>
+        <params>param1$##$param2</params>
+        <postdata> </postdata>
+	<bodytype>string</bodytype>
+	<contenttype>application/json;utf-8</contenttype>
+    </filed>
+
+    <filed method="post" serviceport="8888">
+        <commandname>group_subcmd</commandname>
+        <command>test1/test2</command>
+        <tips>some tips</tips>
+        <params></params>
+        <postdata>postData</postdata>
+	<bodytype>string</bodytype>
+	<contenttype>application/json;utf-8</contenttype>
+    </filed>
+</customcomand>


### PR DESCRIPTION
    When  I using the rest-client tools, I found it's not convince when I want to rerun a rest,
 I need re fill the method/ header/body etc.  hand by hand, even if I did not need to change any field. 
So, I commit this pull request to make up it. 
    when select a url from url combox,  It's will search the historyManager to find the history operation. 
when found one, It will use it to re fill.