### PR TITLE
Auto fill 'method、body、head ......' when select a url from url_combox

### DIFF
--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/FileOpenUtil.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/FileOpenUtil.java
@@ -23,7 +23,7 @@ public class FileOpenUtil {
         try {
             PersistenceRead p = new XmlPersistenceRead();
             Request request = p.getRequestFromFile(f);
-            view.setUIFromRequest(request);
+            view.setUIFromRequest(request, true);
         }
         catch(IOException | XMLException ex){
             e = ex;
@@ -55,7 +55,7 @@ public class FileOpenUtil {
             Request request = encp.getRequestBean();
             Response response = encp.getResponseBean();
             if(request != null && response != null){
-                view.setUIFromRequest(request);
+                view.setUIFromRequest(request,true);
                 view.setUIFromResponse(response);
             }
             else{

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTMain.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTMain.java
@@ -259,7 +259,7 @@ class RESTMain implements RESTUserInterface {
             @Override
             public void actionPerformed(ActionEvent e) {
                 view.clearUIResponse();
-                view.clearUIRequest();
+                view.clearUIRequest(true);
             }
         });
         jm_edit.add(jmi_reset_all);
@@ -297,13 +297,13 @@ class RESTMain implements RESTUserInterface {
                     try {
                         Request reqFromUi = view.getRequestFromUI();
                         if(!reqFromUi.equals(historyManager.current())) {
-                            view.setUIFromRequest(historyManager.current());
+                            view.setUIFromRequest(historyManager.current(), true);
                             return;
                         }
                     }
                     catch(IllegalStateException ex) {
                         if(historyManager.current() != null) {
-                            view.setUIFromRequest(historyManager.current());
+                            view.setUIFromRequest(historyManager.current(), true);
                             return;
                         }
                     }
@@ -313,7 +313,7 @@ class RESTMain implements RESTUserInterface {
                 if(!historyManager.isOldest()) {
                     Request request = historyManager.back();
                     if(request != null) {
-                        view.setUIFromRequest(request);
+                        view.setUIFromRequest(request, true);
                     }
                 }
                 else {
@@ -332,7 +332,7 @@ class RESTMain implements RESTUserInterface {
                 if(!historyManager.isMostRecent()) {
                     Request request = historyManager.forward();
                     if(request != null) {
-                        view.setUIFromRequest(request);
+                        view.setUIFromRequest(request, true);
                     }
                 }
                 else {

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTView.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTView.java
@@ -6,6 +6,7 @@ import java.awt.Font;
 import org.wiztools.restclient.View;
 import org.wiztools.restclient.bean.Request;
 import org.wiztools.restclient.bean.Response;
+import org.wiztools.restclient.ui.history.HistoryManager;
 
 /**
  *
@@ -30,6 +31,8 @@ public interface RESTView extends View {
 
     String getUrl();
 
+    HistoryManager getHistoryManager();
+
     void runClonedRequestTest(Request request, Response response);
 
     void setStatusMessage(final String msg);
@@ -45,12 +48,12 @@ public interface RESTView extends View {
 
     void showMessage(final String title, final String message);
     
-    void setUIFromRequest(Request request);
+    void setUIFromRequest(Request request, Boolean isNeedSetUrl);
     void setUIFromResponse(Response response);
     
     void clearUIResponse();
     
-    void clearUIRequest();
+    void clearUIRequest(Boolean isNeedClearUrl);
     
     void setUIToLastRequestResponse();
     

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTViewImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTViewImpl.java
@@ -220,9 +220,14 @@ public class RESTViewImpl extends JPanel implements RESTView {
     @Override
     public void setUIToLastRequestResponse(){
         if(historyManager.lastRequest() != null && lastResponse != null){
-            setUIFromRequest(historyManager.lastRequest());
+            setUIFromRequest(historyManager.lastRequest(), true);
             setUIFromResponse(lastResponse);
         }
+    }
+
+    @Override
+    public HistoryManager getHistoryManager() {
+        return historyManager;
     }
     
     @Override
@@ -498,9 +503,11 @@ public class RESTViewImpl extends JPanel implements RESTView {
     }
     
     @Override
-    public void clearUIRequest() {
+    public void clearUIRequest(Boolean isNeedClearUrl) {
         // URL
-        jp_url_go.clear();
+        if (isNeedClearUrl) {
+            jp_url_go.clear();
+        }
         
         // Method
         jp_req_method.clear();
@@ -553,12 +560,14 @@ public class RESTViewImpl extends JPanel implements RESTView {
     }
     
     @Override
-    public void setUIFromRequest(final Request request){
+    public void setUIFromRequest(final Request request, Boolean isNeedSetUrl){
         // Clear first
-        clearUIRequest();
+        clearUIRequest(isNeedSetUrl);
 
         // URL
-        jp_url_go.setUrlString(request.getUrl().toString());
+        if (isNeedSetUrl) {
+            jp_url_go.setUrlString(request.getUrl().toString());
+        }
 
         // Method
         final HTTPMethod reqMethod = request.getMethod();

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTViewImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/RESTViewImpl.java
@@ -504,35 +504,37 @@ public class RESTViewImpl extends JPanel implements RESTView {
     
     @Override
     public void clearUIRequest(Boolean isNeedClearUrl) {
-        // URL
-        if (isNeedClearUrl) {
-            jp_url_go.clear();
-        }
-        
         // Method
         jp_req_method.clear();
-        
-        // Headers
-        jp_2col_req_headers.setData(CollectionsUtil.EMPTY_MULTI_VALUE_MAP);
-        
-        // Cookies
-        jp_2col_req_cookies.setData(CollectionsUtil.EMPTY_MULTI_VALUE_MAP);
-        
+
         // Body
         jp_req_body.clear();
-        jp_req_body.disableBody();
-        
-        // Auth
-        jp_req_auth.clear();
-        
-        // SSL
-        jp_req_ssl.clear();
-        
-        // Etc panel
-        jp_req_etc.clear();
-        
-        // Script
-        jp_req_test.clear();
+
+        if (isNeedClearUrl) {
+            // URL
+            jp_url_go.clear();
+            
+            // Headers
+            jp_2col_req_headers.setData(CollectionsUtil.EMPTY_MULTI_VALUE_MAP);
+
+            // Cookies
+            jp_2col_req_cookies.setData(CollectionsUtil.EMPTY_MULTI_VALUE_MAP);
+
+            // Auth
+            jp_req_auth.clear();
+
+            // SSL
+            jp_req_ssl.clear();
+
+            // Etc panel
+            jp_req_etc.clear();
+
+            // Script
+            jp_req_test.clear();
+			
+            // disable body
+            jp_req_body.disableBody();
+        }
     }
     
     @Override

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/history/HistoryManager.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/history/HistoryManager.java
@@ -34,6 +34,10 @@ public interface HistoryManager {
     boolean isEmpty();
 
     void clear();
+
+    void setCursor(int sCurtor);
+
+    int cursor();
     
     void save(File file) throws IOException;
     void load(File file) throws IOException;

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/history/HistoryManagerImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/history/HistoryManagerImpl.java
@@ -95,6 +95,11 @@ public class HistoryManagerImpl implements HistoryManager {
             options.setProperty(HISTORY_SIZE_CONFIG_KEY, String.valueOf(maxSize));
         }
     }
+
+    @Override
+    public void setCursor(int sCurtor) {
+        cursor = sCurtor;
+    }
     
     @Override
     public int getHistorySize() {
@@ -220,7 +225,8 @@ public class HistoryManagerImpl implements HistoryManager {
     public int size() {
         return data.size();
     }
-    
+
+    @Override
     public int cursor() {
         return cursor;
     }

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanel.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanel.java
@@ -14,6 +14,8 @@ public interface ReqUrlGoPanel extends ViewPanel {
     
     void setAsRunning();
     void setAsIdle();
+
+    void setTrimFlag(Boolean flag);
     
     void clearHistory();
     

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
@@ -99,6 +99,8 @@ public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
                         if (e.getStateChange() == ItemEvent.DESELECTED) {
                             rest_ui.getView().setUIFromRequest(matchRequest, false);
                         }
+                    } else {
+                        rest_ui.getView().clearUIRequest(false);
                     }
                 }
 

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
@@ -14,9 +14,11 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.swing.*;
 import org.wiztools.commons.StringUtil;
+import org.wiztools.restclient.bean.Request;
 import org.wiztools.restclient.ui.RESTUserInterface;
 import org.wiztools.restclient.ui.RESTView;
 import org.wiztools.restclient.ui.UIUtil;
+import org.wiztools.restclient.ui.history.HistoryManager;
 
 /**
  *
@@ -39,7 +41,33 @@ public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
     private final JButton jb_request = new JButton(icon_go);
     
     private final List<ActionListener> listeners = new ArrayList<>();
-    
+
+    private Request findMatchUrl(HistoryManager historyManger, String matchingUrl){
+        int currentCursor = historyManger.cursor();
+        Request backRequest;
+        Request forwardRequest;
+        Request currentRequest = historyManger.current();
+        if (null != currentRequest && currentRequest.getUrl().toString().equals(matchingUrl)) {
+            return currentRequest;
+        }
+        backRequest = historyManger.back();
+        while (null != backRequest) {
+            if (backRequest.getUrl().toString().equals(matchingUrl)) {
+                return backRequest;
+            }
+            backRequest = historyManger.back();
+        }
+        historyManger.setCursor(currentCursor);
+        forwardRequest = historyManger.forward();
+        while ( null != forwardRequest) {
+            if (forwardRequest.getUrl().toString().equals(matchingUrl)) {
+                return forwardRequest;
+            }
+            forwardRequest = historyManger.forward();
+        }
+        return null;
+    }
+
     @PostConstruct
     protected void init() {
         { // Keystroke for focusing on the address bar:
@@ -55,6 +83,27 @@ public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
                 }
             });
         }
+
+        // when url is selected, search the history and set method,body etc.
+        jcb_url.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                String url = "";
+                HistoryManager historyManager = rest_ui.getView().getHistoryManager();
+                Object urlObject = jcb_url.getSelectedItem();
+                if (null != urlObject) {
+                    url = urlObject.toString();
+                    Request matchRequest = findMatchUrl(historyManager, url);
+                    if (null != matchRequest) {
+                        // set method,body etc.
+                        if (e.getStateChange() == ItemEvent.DESELECTED) {
+                            rest_ui.getView().setUIFromRequest(matchRequest, false);
+                        }
+                    }
+                }
+
+            }
+        });
         
         // Layout follows:
         

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/ReqUrlGoPanelImpl.java
@@ -28,10 +28,14 @@ import org.wiztools.restclient.ui.history.HistoryManager;
 public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
     
     private static final Logger LOG = Logger.getLogger(ReqUrlGoPanelImpl.class.getName());
-    
-    @Inject private RESTUserInterface rest_ui;
-    @Inject private UrlComboBox jcb_url;
-    
+
+    @Inject
+    private RESTUserInterface rest_ui;
+    @Inject
+    private UrlComboBox jcb_url;
+
+    private Boolean go_trim_flag = true;
+
     private final ImageIcon icon_go = UIUtil.getIconFromClasspath("org/wiztools/restclient/go.png");
     private final ImageIcon icon_stop = UIUtil.getIconFromClasspath("org/wiztools/restclient/stop.png");
     
@@ -88,22 +92,25 @@ public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
         jcb_url.addItemListener(new ItemListener() {
             @Override
             public void itemStateChanged(ItemEvent e) {
-                String url = "";
-                HistoryManager historyManager = rest_ui.getView().getHistoryManager();
-                Object urlObject = jcb_url.getSelectedItem();
-                if (null != urlObject) {
-                    url = urlObject.toString();
-                    Request matchRequest = findMatchUrl(historyManager, url);
-                    if (null != matchRequest) {
-                        // set method,body etc.
-                        if (e.getStateChange() == ItemEvent.DESELECTED) {
-                            rest_ui.getView().setUIFromRequest(matchRequest, false);
+                if (go_trim_flag) {
+                    if (e.getStateChange() == ItemEvent.SELECTED) {
+                        String url = "";
+                        HistoryManager historyManager = rest_ui.getView().getHistoryManager();
+                        Object urlObject = jcb_url.getSelectedItem();
+                        if (null != urlObject) {
+                            url = urlObject.toString();
+                            Request matchRequest = findMatchUrl(historyManager, url);
+                            if (null != matchRequest) {
+                                // set method,body etc.
+                                rest_ui.getView().setUIFromRequest(matchRequest, false);
+                            } else {
+                                rest_ui.getView().clearUIRequest(false);
+                            }
                         }
-                    } else {
-                        rest_ui.getView().clearUIRequest(false);
                     }
+                } else {
+                    setTrimFlag(true);
                 }
-
             }
         });
         
@@ -165,6 +172,7 @@ public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
 
     @Override
     public void setUrlString(String url) {
+        setTrimFlag(false);
         jcb_url.setSelectedItem(url);
     }
 
@@ -204,6 +212,11 @@ public class ReqUrlGoPanelImpl extends JPanel implements ReqUrlGoPanel {
     public void setAsIdle() {
         jb_request.setIcon(icon_go);
         jb_request.setToolTipText(TEXT_GO);
+    }
+
+    @Override
+    public void setTrimFlag(Boolean flag) {
+        go_trim_flag = flag;
     }
 
     @Override

--- a/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/UrlComboBox.java
+++ b/restclient-ui/src/main/java/org/wiztools/restclient/ui/reqgo/UrlComboBox.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 import javax.swing.JComboBox;
 import javax.swing.JTextField;
 import org.wiztools.commons.StringUtil;
@@ -24,6 +25,9 @@ public class UrlComboBox extends JComboBox<String> {
     private static final Logger LOG = Logger.getLogger(UrlComboBox.class.getName());
     
     private final int URL_COUNT_SIZE = 20;
+
+    @Inject
+    private ReqUrlGoPanel reqGo;
 
     public UrlComboBox() {
         setToolTipText("URL");
@@ -87,27 +91,26 @@ public class UrlComboBox extends JComboBox<String> {
 
         final int count = getItemCount();
         final LinkedList<String> l = new LinkedList<>();
-        for(int i=0; i<count; i++){
+        for (int i = 0; i < count; i++) {
             l.add(getItemAt(i));
         }
-        if(l.contains(item)){ // Item already present
+        if (l.contains(item)) { // Item already present
             // Remove and add to bring it to the top
-            removeItem(item);
-            insertItemAt(item, 0);
+            l.remove(item);
         }
-        else{ // Add new item
-            if(item.trim().length() != 0 ) {
-                // The total number of items should not exceed 20
-                if(count >= URL_COUNT_SIZE){
-                    // Remove last item to give place
-                    // to new one
-                    removeItemAt(count - 1);
-                }
-                //l.addFirst(item);
-                insertItemAt(item, 0);
-            }
+
+        l.add(0, item);
+        // do not need trim events, to motify like this is to
+		// avoid trim twice IntemChange Event!
+        reqGo.setTrimFlag(false);
+        removeAllItems();
+        for (int i = 0; i < Math.min(l.size(), URL_COUNT_SIZE); i++) {
+            reqGo.setTrimFlag(false);
+            addItem(l.get(i));
         }
+
         // make the selected item is the item we want
+        reqGo.setTrimFlag(false);
         setSelectedItem(item);
     }
 }


### PR DESCRIPTION
@subwiz please review this PR, the commit "add customrized panel for rest-client" have not test fully.
When  I using the rest-client tools, I found it's not convince when I want to rerun a rest,
I need re fill the method/ header/body etc. hand by hand, even if I did not need to change any field.
So, I commit this pull request to make up it.
when select a url from url combox, It's will search the historyManager to find the history operation.
when found one, It will use it to re fill.